### PR TITLE
Concurrent send fix

### DIFF
--- a/Indicative/Indicative.m
+++ b/Indicative/Indicative.m
@@ -289,11 +289,11 @@ static Indicative* mIndicative = nil;
                 NSInteger statusCode = [self postRequest:postData];
                 
                 if(INDICATIVE_DEBUG) {
-                    NSLog(@"Received status code: %d", statusCode);
+                    NSLog(@"Received status code: %ld", (long)statusCode);
                 }
                 
                 if(statusCode == 0 || statusCode >= 400) {
-                    NSLog(@"Error while sending events to Indicative: HTTP %d", statusCode);
+                    NSLog(@"Error while sending events to Indicative: HTTP %ld", (long)statusCode);
                     break;
                 }
                 
@@ -302,7 +302,7 @@ static Indicative* mIndicative = nil;
                 totalSent += batch.count;
                 
                 if(INDICATIVE_DEBUG) {
-                    NSLog(@"Sent batch of %d events", batch.count);
+                    NSLog(@"Sent batch of %ld events", (long)batch.count);
                 }
             }
             @catch (NSException* ex) {
@@ -312,7 +312,7 @@ static Indicative* mIndicative = nil;
         }
         
         if(INDICATIVE_DEBUG && totalSent > 0) {
-            NSLog(@"Done sending events. Sent %d total", totalSent);
+            NSLog(@"Done sending events. Sent %ld total", (long)totalSent);
         }
         
         if(callback) {
@@ -344,7 +344,7 @@ static Indicative* mIndicative = nil;
     [req setHTTPBody:postData];
     [req setValue:@"iOS" forHTTPHeaderField: @"Indicative-Client"];
     [req setValue:@"application/json" forHTTPHeaderField: @"Content-Type"];
-    [req setValue:[NSString stringWithFormat:@"%d", postData.length] forHTTPHeaderField:@"Content-Length"];
+    [req setValue:[NSString stringWithFormat:@"%lu", (unsigned long)postData.length] forHTTPHeaderField:@"Content-Length"];
     
 	NSHTTPURLResponse* resp = nil;
     NSInteger statusCode = 0;
@@ -359,7 +359,7 @@ static Indicative* mIndicative = nil;
             NSLog(@"Status Code from Indicative: %li %@", (long)urlResponse.statusCode, [NSHTTPURLResponse localizedStringForStatusCode:urlResponse.statusCode]);
             NSLog(@"Response Body from Indicative: %@", [[NSString alloc] initWithData:nsData encoding:NSUTF8StringEncoding]);
         } else {
-            NSLog(@"An error occured with your request to Indicative, Status Code: %i", urlResponse.statusCode);
+            NSLog(@"An error occured with your request to Indicative, Status Code: %li", (long)urlResponse.statusCode);
             NSLog(@"Indicative Response Error Description: %@", [error localizedDescription]);
             NSLog(@"Indicative Response Body: %@", [[NSString alloc] initWithData:nsData encoding:NSUTF8StringEncoding]);
         }


### PR DESCRIPTION
Fix an issue that resulted in overlapping send attempts when sending events took longer than the send interval.
By using a single serial queue, we can ensure that sends are processed in order, making the operation effectively atomic. This will prevent duplicated events and array range errors when trying to request events that have been removed.
